### PR TITLE
[FEAT] resume 페이지 레이아웃 및 직업 목록 API 프리패치 코드 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@tanstack/react-query": "^4.33.0",
+    "@tanstack/react-query-devtools": "^4.33.0",
     "@types/node": "20.5.1",
     "@types/react": "18.2.20",
     "@types/react-dom": "18.2.7",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,8 +10,19 @@
   box-sizing: border-box;
   padding: 0;
   margin: 0;
+  color: #383c3a;
 }
 
 body {
   overflow: hidden;
+}
+
+select {
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+}
+
+select:focus {
+  outline: none;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import ClientProvider from "@/components/client/ClientProvider";
 import "./globals.css";
 import type { Metadata } from "next";
 import { IBM_Plex_Sans_KR } from "next/font/google";
@@ -22,7 +23,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body className={ibmKr.className}>{children}</body>
+      <body className={ibmKr.className}>
+        <ClientProvider>{children}</ClientProvider>
+      </body>
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,10 @@ import ClientProvider from "@/components/client/ClientProvider";
 import "./globals.css";
 import type { Metadata } from "next";
 import { IBM_Plex_Sans_KR } from "next/font/google";
+import { getJobs } from "@/service/getJobs";
+import { dehydrate } from "@tanstack/react-query";
+import HydrateOnClient from "@/store/hydrateOnClient";
+import getQueryClient from "@/store";
 
 const ibmKr = IBM_Plex_Sans_KR({
   subsets: ["latin"],
@@ -16,15 +20,25 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // TODO: 코드 이동시키기
+  const queryClient = getQueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: ["getJobs"],
+    queryFn: getJobs,
+  });
+  const dehydratedState = dehydrate(queryClient);
+
   return (
     <html lang="ko">
       <body className={ibmKr.className}>
-        <ClientProvider>{children}</ClientProvider>
+        <ClientProvider>
+          <HydrateOnClient state={dehydratedState}>{children}</HydrateOnClient>
+        </ClientProvider>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,11 @@
 import "./globals.css";
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { IBM_Plex_Sans_KR } from "next/font/google";
 
-const inter = Inter({ subsets: ["latin"] });
+const ibmKr = IBM_Plex_Sans_KR({
+  subsets: ["latin"],
+  weight: ["300", "400", "600"],
+});
 
 export const metadata: Metadata = {
   title: "Resumarble",
@@ -19,7 +22,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body className={inter.className}>{children}</body>
+      <body className={ibmKr.className}>{children}</body>
     </html>
   );
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,11 @@
+import Link from "next/link";
+import React from "react";
+
+export default function NotFound() {
+  return (
+    <div>
+      <p>404 NOT FOUND, 잘못된 경로입니다. </p>
+      <Link href="/">메인 페이지로 이동</Link>
+    </div>
+  );
+}

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -59,6 +59,14 @@
   transform: translate(-50%);
 }
 
+.topContent h1 {
+  color: #fff;
+}
+
+.topContent p {
+  color: #fff;
+}
+
 .bottomContent {
 }
 

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+import React, { useEffect, useRef } from "react";
+
+import styles from "./resume.module.css";
+
+import Background from "@/components/bg/Background";
+import { Form } from "@/components/resume/Form";
+
+export default function ResumePage() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    ref.current?.classList.add("move-to-left-and-show");
+  }, []);
+
+  return (
+    <>
+      <Background />
+      <div ref={ref} className={styles.container}>
+        <Form />
+      </div>
+    </>
+  );
+}

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -1,23 +1,39 @@
 "use client";
 import React, { useEffect, useRef } from "react";
-
 import styles from "./resume.module.css";
-
 import Background from "@/components/bg/Background";
 import { Form } from "@/components/resume/Form";
+import { useQuery } from "@tanstack/react-query";
+import { getJobs } from "@/service/getJobs";
 
 export default function ResumePage() {
   const ref = useRef<HTMLDivElement>(null);
+  const {
+    data: jobs,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ["getJobs"],
+    queryFn: getJobs,
+  });
 
   useEffect(() => {
     ref.current?.classList.add("move-to-left-and-show");
   }, []);
 
+  if (isLoading) {
+    return <div>데이터를 불러오고 있어요.</div>;
+  }
+
+  if (isError) {
+    return <div>잠시 후 다시 시도해주세요.</div>;
+  }
+
   return (
     <>
       <Background />
       <div ref={ref} className={styles.container}>
-        <Form />
+        <Form options={jobs} />
       </div>
     </>
   );

--- a/src/app/resume/resume.module.css
+++ b/src/app/resume/resume.module.css
@@ -1,0 +1,15 @@
+.container {
+  width: 500px;
+  min-width: 500px;
+  height: 100vh;
+  margin: 0 auto;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  color: #363636;
+
+  opacity: 0;
+}

--- a/src/components/client/ClientProvider.tsx
+++ b/src/components/client/ClientProvider.tsx
@@ -1,0 +1,19 @@
+"use client";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+export default function ClientProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const queryClient = new QueryClient();
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ReactQueryDevtools />
+      {children}
+    </QueryClientProvider>
+  );
+}

--- a/src/components/resume/Form.tsx
+++ b/src/components/resume/Form.tsx
@@ -1,6 +1,13 @@
+import { Job } from "@/service/getJobs";
 import styles from "./form.module.css";
 
-export const Form = () => {
+type FormProps = {
+  options: { jobs: Job[] };
+};
+
+export const Form = (options: FormProps) => {
+  const jobList = options.options.jobs;
+
   return (
     <>
       <div className={styles.box}>
@@ -13,11 +20,15 @@ export const Form = () => {
               <label htmlFor="select-job">
                 <b>직업을 선택하세요.</b>
               </label>
-              <select required id="select-job">
-                <option value="select" disabled selected>
-                  선택
+              <select defaultValue="default" required id="select-job">
+                <option value="default" disabled>
+                  --- 선택 ---
                 </option>
-                <option value="job">직업1</option>
+                {jobList.map((job, idx) => {
+                  return (
+                    <option key={`${job} ${idx}`}>{job.jobTitleKr}</option>
+                  );
+                })}
               </select>
             </div>
 
@@ -25,9 +36,9 @@ export const Form = () => {
               <label htmlFor="select-career">
                 <b>경력을 선택하세요.</b>
               </label>
-              <select required id="select-career">
-                <option value="select" disabled selected>
-                  선택
+              <select defaultValue="default" required id="select-career">
+                <option value="default" disabled>
+                  --- 선택 ---
                 </option>
                 <option value="job">신입</option>
               </select>
@@ -37,9 +48,9 @@ export const Form = () => {
               <label htmlFor="select-question">
                 <b>예상 질문으로 받고 싶은 항목을 선택하세요.</b>
               </label>
-              <select required id="select-question">
-                <option value="select" disabled selected>
-                  선택
+              <select defaultValue="default" required id="select-question">
+                <option value="default" disabled>
+                  --- 선택 ---
                 </option>
                 <option value="introduce">자기소개</option>
               </select>

--- a/src/components/resume/Form.tsx
+++ b/src/components/resume/Form.tsx
@@ -1,0 +1,61 @@
+import styles from "./form.module.css";
+
+export const Form = () => {
+  return (
+    <>
+      <div className={styles.box}>
+        <h2 className={styles.title}>면접 질문 생성기</h2>
+        <p>작성한 내용을 기반으로 AI가 면접 예상 질문 목록을 생성해요.</p>
+        <hr />
+        <div className={styles.formContainer}>
+          <form>
+            <div className={styles.jobContainer}>
+              <label htmlFor="select-job">
+                <b>직업을 선택하세요.</b>
+              </label>
+              <select required id="select-job">
+                <option value="select" disabled selected>
+                  선택
+                </option>
+                <option value="job">직업1</option>
+              </select>
+            </div>
+
+            <div className={styles.careerContainer}>
+              <label htmlFor="select-career">
+                <b>경력을 선택하세요.</b>
+              </label>
+              <select required id="select-career">
+                <option value="select" disabled selected>
+                  선택
+                </option>
+                <option value="job">신입</option>
+              </select>
+            </div>
+
+            <div className={styles.questionContainer}>
+              <label htmlFor="select-question">
+                <b>예상 질문으로 받고 싶은 항목을 선택하세요.</b>
+              </label>
+              <select required id="select-question">
+                <option value="select" disabled selected>
+                  선택
+                </option>
+                <option value="introduce">자기소개</option>
+              </select>
+            </div>
+
+            <div className={styles.textBoxContainer}>
+              <textarea
+                required
+                placeholder={`내용을 입력해주세요. \n(예상 질문 목록으로 선택한 내용과 유관한 내용 기입)`}
+              />
+            </div>
+            <button className={styles.btn}>제출</button>
+          </form>
+        </div>
+        {/* // TODO 추후 서비스 확장 시 질문 여러개 어떻게 레이아웃 구성할 지 고민해보기 */}
+      </div>
+    </>
+  );
+};

--- a/src/components/resume/form.module.css
+++ b/src/components/resume/form.module.css
@@ -68,8 +68,7 @@
 .btn {
   width: 100%;
   padding: 5px 15px;
-  border: 2px solid #91be9e;
-  background: transparent;
+  background: #313131;
   border-radius: 8px;
 
   cursor: pointer;
@@ -77,5 +76,5 @@
   font-size: 1.1rem;
   font-weight: 400;
 
-  color: #91be9e;
+  color: #fff;
 }

--- a/src/components/resume/form.module.css
+++ b/src/components/resume/form.module.css
@@ -1,0 +1,81 @@
+.box {
+  padding: 40px;
+
+  background-color: #fff;
+  box-shadow: 10px 10px 25px #3157371d;
+
+  border: 1px solid #eee;
+  border-radius: 8px;
+
+  overflow: hidden;
+}
+
+.title {
+  font-size: 1.5rem;
+  margin-bottom: 3px;
+}
+
+.box hr {
+  width: 100%;
+  height: 1px;
+  padding-bottom: 10px;
+  border: none;
+  border-top: 1px solid #ddd;
+
+  margin-bottom: 1rem;
+}
+
+.formContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  gap: 20px;
+}
+
+.jobContainer,
+.careerContainer,
+.questionContainer,
+.textBoxContainer {
+  display: flex;
+  flex-direction: column;
+  margin-top: 10px;
+}
+
+.textBoxContainer textarea {
+  min-width: 400px;
+  max-width: 400px;
+  height: 200px;
+  max-height: 500px;
+
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+
+  margin: 8px 0 16px 0;
+
+  resize: none;
+
+  font-family: "ibm-plex-sans-kr";
+  font-size: 1rem;
+}
+
+.textBoxContainer textarea:focus {
+  outline: none;
+}
+
+.btn {
+  width: 100%;
+  padding: 5px 15px;
+  border: 2px solid #91be9e;
+  background: transparent;
+  border-radius: 8px;
+
+  cursor: pointer;
+
+  font-size: 1.1rem;
+  font-weight: 400;
+
+  color: #91be9e;
+}

--- a/src/service/getJobs.ts
+++ b/src/service/getJobs.ts
@@ -1,0 +1,11 @@
+export type Job = {
+  jobTitleKr: string;
+  jobTitleEn: string;
+};
+
+export async function getJobs() {
+  const jobs = await fetch(`${process.env.NEXT_PUBLIC_SERVER_URL}/jobs`);
+  const res = await jobs.json();
+
+  return res.data;
+}

--- a/src/store/hydrateOnClient.tsx
+++ b/src/store/hydrateOnClient.tsx
@@ -1,0 +1,4 @@
+"use client";
+
+import { Hydrate as HydrateOnClient } from "@tanstack/react-query";
+export default HydrateOnClient;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,5 @@
+import { QueryClient } from "@tanstack/react-query";
+import { cache } from "react";
+
+const getQueryClient = cache(() => new QueryClient());
+export default getQueryClient;

--- a/src/styles/animation.css
+++ b/src/styles/animation.css
@@ -4,8 +4,20 @@
   -webkit-animation-fill-mode: both;
 }
 
+.move-to-left-and-show {
+  animation: moveToLeftAndShow 1s alternate;
+  animation-fill-mode: both;
+  -webkit-animation-fill-mode: both;
+}
+
 .show {
   animation: show 1s linear;
+  animation-fill-mode: both;
+  -webkit-animation-fill-mode: both;
+}
+
+.fast-show {
+  animation: show 0.5s linear;
   animation-fill-mode: both;
   -webkit-animation-fill-mode: both;
 }
@@ -68,5 +80,17 @@
 
   100% {
     transform: translateX(-100vw);
+  }
+}
+
+@keyframes moveToLeftAndShow {
+  0% {
+    opacity: 0;
+    transform: translateX(-200px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateX(0);
   }
 }


### PR DESCRIPTION

![Honeycam 2023-08-27 22-36-45](https://github.com/Resumarble/Resumarble-Frontend/assets/48672106/835fd9df-d7b5-4d3f-8b6e-9d2b0d479404)


## 커밋 사항
- 레이아웃 1차 작업 완료
- 초기 애니메이션 추가
- 직업 목록 API 호출

### 기타
- 직업 외 목록도 API로 받아올지, 프론트에서 정의해서 사용할지 논의 필요