### PR TITLE
[FEAT] result 페이지 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,3 +26,34 @@ select {
 select:focus {
   outline: none;
 }
+
+.btn {
+  width: 350px;
+  padding: 0.5rem;
+
+  color: #fff;
+  border: 1px solid #fff;
+  border-radius: 0.5rem;
+  background: transparent;
+
+  font-size: 1.1rem;
+  cursor: pointer;
+
+  transition: all 0.2s;
+}
+
+.btn:hover {
+  background: #ffffff20;
+}
+
+::-webkit-scrollbar {
+  width: 5px;
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: 0px;
+}
+
+::-webkit-scrollbar-track {
+  background-color: #f1f1f1;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,14 +34,17 @@ export default async function RootLayout({
     queryClient.prefetchQuery({
       queryKey: ["getJobs"],
       queryFn: getJobs,
+      staleTime: 1000 * 3600 * 24,
     }),
     queryClient.prefetchQuery({
       queryKey: ["getCareers"],
       queryFn: getCareers,
+      staleTime: 1000 * 3600 * 24,
     }),
     queryClient.prefetchQuery({
       queryKey: ["getQuestions"],
       queryFn: getQuestion,
+      staleTime: 1000 * 3600 * 24,
     }),
   ]);
 

--- a/src/app/result/components/ResultContainer.tsx
+++ b/src/app/result/components/ResultContainer.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { useEffect, useState } from "react";
+import styles from "./resultContainer.module.css";
+import { Result } from "@/components/resume/Form";
+import Link from "next/link";
+import ToggleBox from "@/components/common/ToggleBox";
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function ResultContainer({ children }: Props) {
+  const [results, setResults] = useState<Result[]>();
+  const hasResult = localStorage.getItem("result")?.length;
+
+  useEffect(() => {
+    if (!hasResult) return;
+
+    setResults(JSON.parse(localStorage.getItem("result")!) ?? []);
+  }, []);
+
+  if (!hasResult) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.box}>
+          <h3>ERROR!</h3>
+          <h4>올바르지 않은 요청입니다.</h4>
+          <Link href={"/resume"}>다시 작성하기</Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <section className={styles.container}>
+      <div className={styles.box}>
+        <div className={styles.header}>
+          <h2>생성된 질문/답변을 확인해보세요.</h2>
+          <p>자세히 작성할수록 예상 질문과 답변의 퀄리티가 높아집니다.</p>
+          <hr />
+        </div>
+
+        {results?.map((result, idx) => {
+          return (
+            <div key={`${result} ${idx}`}>
+              <ToggleBox title={result.question} contents={result.bestAnswer} />
+            </div>
+          );
+        })}
+
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/src/app/result/components/ResultContainer.tsx
+++ b/src/app/result/components/ResultContainer.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import ToggleBox from "@/components/common/ToggleBox";
 
 type Props = {
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 export default function ResultContainer({ children }: Props) {

--- a/src/app/result/components/resultContainer.module.css
+++ b/src/app/result/components/resultContainer.module.css
@@ -1,0 +1,34 @@
+.container {
+  width: 500px;
+  min-width: 500px;
+  height: 800px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  color: #363636;
+
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.box {
+  height: 100vh;
+  padding: 40px;
+
+  background-color: #fff;
+  box-shadow: 10px 10px 25px #3157371d;
+
+  overflow: hidden;
+  overflow-y: scroll;
+}
+
+.header {
+  margin-bottom: 2rem;
+}
+
+.content {
+  margin-bottom: 10px;
+}

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -1,0 +1,19 @@
+import Background from "@/components/bg/Background";
+import ResultContainer from "./components/ResultContainer";
+import Link from "next/link";
+import styles from "./result.module.css";
+
+export default function ResultPage() {
+  return (
+    <>
+      <Background />
+      <div className={styles.container}>
+        <ResultContainer>
+          <button className={`${styles.retryBtn}`}>
+            <Link href={"/resume"}>다시 생성하기</Link>
+          </button>
+        </ResultContainer>
+      </div>
+    </>
+  );
+}

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -10,12 +10,17 @@ export default function ResultPage() {
       <div className={styles.container}>
         <ResultContainer />
         <div className={`${styles.btns}`}>
-          <button className={`${styles.btn} ${styles.retryBtn}`}>
-            <Link href={"/resume"}>다시 생성하기</Link>
-          </button>
-          <button className={`${styles.btn} ${styles.saveBtn}`}>
-            <Link href={"/resume"}>저장하기</Link>
-          </button>
+          <Link href={"/resume"}>
+            <button className={`${styles.btn} ${styles.retryBtn}`}>
+              다시 생성하기
+            </button>
+          </Link>
+
+          <Link href={"/resume"}>
+            <button className={`${styles.btn} ${styles.saveBtn}`}>
+              저장하기
+            </button>
+          </Link>
         </div>
       </div>
     </>

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -8,11 +8,15 @@ export default function ResultPage() {
     <>
       <Background />
       <div className={styles.container}>
-        <ResultContainer>
-          <button className={`${styles.retryBtn}`}>
+        <ResultContainer />
+        <div className={`${styles.btns}`}>
+          <button className={`${styles.btn} ${styles.retryBtn}`}>
             <Link href={"/resume"}>다시 생성하기</Link>
           </button>
-        </ResultContainer>
+          <button className={`${styles.btn} ${styles.saveBtn}`}>
+            <Link href={"/resume"}>저장하기</Link>
+          </button>
+        </div>
       </div>
     </>
   );

--- a/src/app/result/result.module.css
+++ b/src/app/result/result.module.css
@@ -1,0 +1,41 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  height: 100vh;
+
+  position: relative;
+}
+
+.retryBtn {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  right: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 2.3rem;
+
+  width: 200px;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 100px;
+
+  font-size: 1.05rem;
+
+  background: #313131;
+
+  cursor: pointer;
+
+  box-shadow: 5px 5px 8px #6868684f;
+}
+
+.retryBtn:hover {
+  background-color: #292a2a;
+}
+
+.retryBtn a {
+  color: #fff;
+  text-decoration: none;
+}

--- a/src/app/result/result.module.css
+++ b/src/app/result/result.module.css
@@ -4,38 +4,59 @@
   justify-content: center;
   align-items: center;
 
-  height: 100vh;
-
   position: relative;
+  height: 100vh;
 }
 
-.retryBtn {
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-  right: 50%;
-  transform: translateX(-50%);
-  margin-bottom: 2.3rem;
+.btns {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 15px;
 
-  width: 200px;
+  position: absolute;
+  bottom: 35px;
+
+  z-index: 5;
+}
+
+.btn {
+  width: 240px;
   padding: 8px 10px;
+
   border: none;
-  border-radius: 100px;
+  border-radius: 7px;
 
   font-size: 1.05rem;
 
   background: #313131;
+  box-shadow: 5px 5px 8px #6868684f;
 
   cursor: pointer;
+  transition: all 0.3s;
+}
 
-  box-shadow: 5px 5px 8px #6868684f;
+.btn a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.retryBtn {
+  background: #313131;
 }
 
 .retryBtn:hover {
   background-color: #292a2a;
 }
 
-.retryBtn a {
-  color: #fff;
-  text-decoration: none;
+.saveBtn {
+  background: #ffffff80;
+}
+
+.saveBtn:hover {
+  background: #ffffff94;
+}
+
+.saveBtn a {
+  color: #313131;
 }

--- a/src/app/result/result.module.css
+++ b/src/app/result/result.module.css
@@ -36,12 +36,9 @@
   transition: all 0.3s;
 }
 
-.btn a {
+.retryBtn {
   color: #fff;
   text-decoration: none;
-}
-
-.retryBtn {
   background: #313131;
 }
 
@@ -50,13 +47,10 @@
 }
 
 .saveBtn {
+  color: #313131;
   background: #ffffff80;
 }
 
 .saveBtn:hover {
   background: #ffffff94;
-}
-
-.saveBtn a {
-  color: #313131;
 }

--- a/src/components/common/ToggleBox.tsx
+++ b/src/components/common/ToggleBox.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from "react";
+import styles from "./toggleBox.module.css";
+
+type Props = {
+  title: string;
+  contents: string;
+  children?: React.ReactNode;
+};
+
+export default function ToggleBox({
+  title,
+  contents,
+  children,
+}: Props): JSX.Element {
+  const [isShow, setIsShow] = useState(false);
+  const [arrowDirection, setArrowDirection] = useState("down");
+
+  const handleTitleClick = () => {
+    setIsShow((prev) => !prev);
+    setArrowDirection((prev) => {
+      return prev === "down" ? "up" : "down";
+    });
+  };
+
+  return (
+    <div className={styles.container}>
+      <h2 onClick={handleTitleClick} className={styles.title}>
+        {title}
+        <i
+          className={`${styles.arrow} ${styles[arrowDirection]}`}
+          role="img"
+        ></i>
+      </h2>
+
+      {isShow && (
+        <p className={`${styles.contents} ${isShow && styles.show}`}>
+          {contents}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/common/toggleBox.module.css
+++ b/src/components/common/toggleBox.module.css
@@ -1,0 +1,71 @@
+.container {
+  margin-bottom: 1rem;
+  position: relative;
+}
+
+.title {
+  padding: 10px;
+  font-size: 1rem;
+  background-color: #f8f8f8;
+  cursor: pointer;
+  position: relative;
+}
+
+.contents {
+  padding: 0 10px;
+
+  overflow: hidden;
+
+  animation: scaleY 0.4s alternate;
+  animation-fill-mode: both;
+  -webkit-animation-fill-mode: both;
+}
+
+.show {
+  max-height: 100%;
+  padding: 10px;
+
+  animation: scaleY 0.4s alternate;
+  animation-fill-mode: both;
+  -webkit-animation-fill-mode: both;
+}
+
+.arrow {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 5px;
+  height: 5px;
+  padding: 10px;
+}
+
+.arrow:before {
+  position: absolute;
+  left: 0;
+  top: 0;
+  content: "";
+  width: 5px;
+  height: 5px;
+  border-top: 2px solid #000;
+  border-right: 2px solid #000;
+}
+
+.up:before {
+  transform: rotate(315deg);
+}
+
+.down:before {
+  transform: rotate(135deg);
+}
+
+@keyframes scaleY {
+  0% {
+    opacity: 0;
+    transform: scaleY(0.8);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}

--- a/src/components/common/toggleBox.module.css
+++ b/src/components/common/toggleBox.module.css
@@ -4,7 +4,7 @@
 }
 
 .title {
-  padding: 10px;
+  padding: 10px 15px;
   font-size: 1rem;
   background-color: #f8f8f8;
   cursor: pointer;

--- a/src/components/resume/Form.tsx
+++ b/src/components/resume/Form.tsx
@@ -9,12 +9,20 @@ import { Career } from "@/service/getCareer";
 import { Question } from "@/service/getQuestion";
 import { useMutation } from "@tanstack/react-query";
 import { PostResume, postResume } from "@/service/postResume";
+import { useRouter } from "next/navigation";
 
 type FormProps = {
   options: [jobs: Job[], careers: Career[], questions: Question[]];
 };
 
+export type Result = {
+  question: string;
+  bestAnswer: string;
+};
+
 export const Form = ({ options }: FormProps) => {
+  const router = useRouter();
+
   const [jobs, careers, questions] = [...options];
 
   const [inputForm, setInputForm] = useState({
@@ -60,8 +68,12 @@ export const Form = ({ options }: FormProps) => {
     onMutate: () => {
       setShowLoading(true);
     },
-    onSuccess: () => {
+    onSuccess: (res) => {
       setShowLoading(false);
+
+      localStorage.setItem("result", JSON.stringify(res.data.interviews));
+
+      router.push("/result");
     },
     onError: () => {
       //  TODO 에러 페이지로 라우트


### PR DESCRIPTION

![Honeycam 2023-09-03 02-34-36](https://github.com/Resumarble/Resumarble-Frontend/assets/48672106/994235a3-1a1b-4594-84a7-fc9253d48887)


## 커밋 사항
- Form으로 기입한 내용을 기반한 질문과 답변이 생성이 되면 결과 페이지에 렌더링
- 타이틀을 클릭하면 컨텐츠가 보이는 토글 방식으로 구현
- 로컬스토리지를 사용하여 받아온 데이터를 저장 후 result 페이지에 렌더링
- 다시 생성하기 버튼을 누르면 /resume 경로로 라우트

### 기타
- 로컬스토리지를 사용했기 때문에 비회원이더라도 가장 최근에 받아본 결과를 다시 확인할 수 있을듯 함. (뒤로가기 버튼을 눌렀다가 다시 result 페이지로 와도 로컬 스토리지에 저장된 데이터를 불러옴)
- 데이터를 저장하는 로직 구현 필요
