### PR TITLE
[REFACTOR, FEAT] 컴포넌트 분리, resume 페이지 3번째 스텝 상태 추가

### DIFF
--- a/src/app/resume/components/FormSection.tsx
+++ b/src/app/resume/components/FormSection.tsx
@@ -1,61 +1,75 @@
-import { Dispatch, SetStateAction } from "react";
-import styles from "./formSection.module.css";
+"use client";
 
-type SelectedInputsType = {
-  job: number;
-  career: number;
-  questions: {
-    question: number;
-    questionTextArea: string;
-  }[];
+import { Dispatch, SetStateAction, useState } from "react";
+import styles from "./formSection.module.css";
+import { RadioInput } from "./RadioInput";
+import { careersMapping, jobsMapping } from "../constants/mapping";
+
+export type QuestionType = {
+  question: number;
+  questionTextArea: string;
 };
 
+export type SelectedInputsType = {
+  job: number;
+  career: number;
+  questions: QuestionType[];
+};
+
+export const jobs = [
+  "백엔드 개발자",
+  "프론트 개발자",
+  "풀스택 개발자",
+  "데이터 엔지니어",
+];
+
+export const careers = [
+  "신입",
+  "1~3년 차 (주니어)",
+  "4~7년 차 (미들)",
+  "7년 차 이상 (시니어)",
+];
+
+const labels = ["자기소개", "기술스택", "경력사항", "프로젝트 경험"];
+
 export default function FormSection({
-  section,
+  step,
   selectedInputs,
   setSelectedInputs,
 }: {
-  section: number;
+  step: number;
   selectedInputs: SelectedInputsType;
   setSelectedInputs: Dispatch<SetStateAction<SelectedInputsType>>;
 }) {
-  // TODO 섹션 변경 시 현재 선택한 옵션이 저장되어있지 않음
-  // 디폴트 설정해놓고 파라미터로 받아서 체크 설정해줘야할듯
-
+  const [partSectionNumber, setPartSectionNumber] = useState(0);
   const onChangeRadio =
-    (key: "job" | "career" | "question") =>
+    ({
+      key,
+      sectionNumber,
+    }: {
+      key: "job" | "career" | "question";
+      sectionNumber?: number;
+    }) =>
     (e: React.ChangeEvent<HTMLInputElement>) => {
       if (key === "question") {
-        const id = parseInt(e.target.id);
-        return setSelectedInputs((prev) => ({
+        const id = e.target.id;
+
+        if (sectionNumber === undefined) return;
+        return setSelectedInputs((prev) => {
+          const newQuestions = prev.questions;
+          newQuestions[sectionNumber].question = Number(id);
+
+          return { ...prev, questions: newQuestions };
+        });
+      } else {
+        setSelectedInputs((prev) => ({
           ...prev,
-          questions: [
-            {
-              question: id,
-              questionTextArea: prev.questions[0].questionTextArea,
-            },
-          ],
+          [key]: parseInt(e.target.id),
         }));
       }
-      setSelectedInputs((prev) => ({
-        ...prev,
-        [key]: parseInt(e.target.id),
-      }));
     };
 
-  const onChangeText = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setSelectedInputs((prev) => ({
-      ...prev,
-      questions: [
-        {
-          question: prev.questions[0].question,
-          questionTextArea: e.target.value,
-        },
-      ],
-    }));
-  };
-
-  switch (section) {
+  switch (step) {
     case 0: {
       return (
         <div key={0}>
@@ -64,59 +78,19 @@ export default function FormSection({
             선택하세요.
           </h5>
           <div className={styles.radioInputBox}>
-            <input
-              onChange={onChangeRadio("job")}
-              checked={selectedInputs.job === 0}
-              className={styles.radio}
-              name="job"
-              id="0"
-              type="radio"
-              value="Backend Engineer"
-            />
-            <label className={styles.label} htmlFor="0">
-              백엔드 개발자
-            </label>
-
-            <input
-              onChange={onChangeRadio("job")}
-              checked={selectedInputs.job === 1}
-              className={styles.radio}
-              name="job"
-              id="1"
-              type="radio"
-              value="Frontend Engineer"
-            />
-            <label className={styles.label} htmlFor="1">
-              프론트 개발자
-            </label>
-
-            <input
-              onChange={onChangeRadio("job")}
-              checked={selectedInputs.job === 2}
-              className={styles.radio}
-              name="job"
-              id="2"
-              type="radio"
-              value="Fullstack Engineer"
-            />
-            <label className={styles.label} htmlFor="2">
-              풀스택 개발자
-            </label>
-
-            <input
-              onChange={onChangeRadio("job")}
-              checked={selectedInputs.job === 3}
-              className={styles.radio}
-              name="job"
-              id="3"
-              type="radio"
-              value="Data Engineer"
-            />
-            <label className={styles.label} htmlFor="3">
-              데이터 엔지니어
-            </label>
+            {jobs.map((job, i) => (
+              <RadioInput
+                key={`${job} ${i}`}
+                onChange={onChangeRadio({ key: "job" })}
+                checked={selectedInputs.job === i}
+                name="job"
+                id={i.toString()}
+                value={jobsMapping[i as keyof typeof jobsMapping]}
+                label={job}
+                htmlFor={i.toString()}
+              />
+            ))}
           </div>
-          {/* <Form options={options} /> */}
         </div>
       );
     }
@@ -128,57 +102,18 @@ export default function FormSection({
             선택하세요.
           </h5>
           <div className={styles.radioInputBox}>
-            <input
-              onChange={onChangeRadio("career")}
-              checked={selectedInputs.career === 0}
-              className={styles.radio}
-              name="career"
-              id="0"
-              type="radio"
-              value="Newcomer"
-            />
-            <label className={styles.label} htmlFor="0">
-              신입
-            </label>
-
-            <input
-              onChange={onChangeRadio("career")}
-              checked={selectedInputs.career === 1}
-              className={styles.radio}
-              name="career"
-              id="1"
-              type="radio"
-              value="1~3 years (Junior)"
-            />
-            <label className={styles.label} htmlFor="1">
-              1~3년 차 (주니어)
-            </label>
-
-            <input
-              onChange={onChangeRadio("career")}
-              checked={selectedInputs.career === 2}
-              className={styles.radio}
-              name="career"
-              id="2"
-              type="radio"
-              value="4~7 years (middle)"
-            />
-            <label className={styles.label} htmlFor="2">
-              4~7년 차 (미들)
-            </label>
-
-            <input
-              onChange={onChangeRadio("career")}
-              checked={selectedInputs.career === 3}
-              className={styles.radio}
-              name="career"
-              id="3"
-              type="radio"
-              value="7 years and up (senior)"
-            />
-            <label className={styles.label} htmlFor="3">
-              7년 차 이상 (시니어)
-            </label>
+            {careers.map((career, i) => (
+              <RadioInput
+                key={`${career} ${i}`}
+                onChange={onChangeRadio({ key: "career" })}
+                checked={selectedInputs.career === i}
+                name="career"
+                id={i.toString()}
+                value={careersMapping[i as keyof typeof careersMapping]}
+                label={career}
+                htmlFor={i.toString()}
+              />
+            ))}
           </div>
         </div>
       );
@@ -196,103 +131,37 @@ export default function FormSection({
             여러 개의 항목을 작성하고 싶을 경우, 우측의 숫자 버튼을 눌러
             추가해보세요.
           </p>
+
           <div className={styles.questionBtns}>
-            <input
-              readOnly
-              checked={true}
-              id="qs1"
-              name="question-section"
-              type="radio"
-            />
-            <label htmlFor="qs1">1</label>
-
-            <input
-              onClick={() => {
-                window.alert("준비중입니다.");
-              }}
-              readOnly
-              checked={false}
-              id="qs2"
-              name="question-section"
-              type="radio"
-            />
-            <label htmlFor="qs2">2</label>
-
-            <input
-              readOnly
-              onClick={() => {
-                window.alert("준비중입니다.");
-              }}
-              checked={false}
-              id="qs3"
-              name="question-section"
-              type="radio"
-            />
-            <label htmlFor="qs3">3</label>
+            {Array(3)
+              .fill(0)
+              .map((numberBtn, i) => (
+                <>
+                  <input
+                    key={`${numberBtn} ${i}`}
+                    readOnly
+                    checked={partSectionNumber === i}
+                    id={`qs${i}`}
+                    name="question-section"
+                    type="radio"
+                    onChange={() => {
+                      setPartSectionNumber(i);
+                    }}
+                  />
+                  <label htmlFor={`qs${i}`}>{i + 1}</label>
+                </>
+              ))}
           </div>
+
           <div className={styles.inputsContainer}>
-            <div className={styles.radioInputBox}>
-              <input
-                onChange={onChangeRadio("question")}
-                //  TODO 여러개 입력 가능하게 할 경우 questions[i] 로 변경
-                checked={selectedInputs.questions[0].question === 0}
-                className={styles.radio}
-                name="question"
-                id="0"
-                type="radio"
-                value="introduction"
+            {
+              <SectionForm
+                selectedInputs={selectedInputs}
+                setSelectedInputs={setSelectedInputs}
+                onChangeRadio={onChangeRadio}
+                partSectionNumber={partSectionNumber}
               />
-              <label className={styles.label} htmlFor="0">
-                자기소개
-              </label>
-
-              <input
-                onChange={onChangeRadio("question")}
-                checked={selectedInputs.questions[0].question === 1}
-                className={styles.radio}
-                name="question"
-                id="1"
-                type="radio"
-                value="technology stack"
-              />
-              <label className={styles.label} htmlFor="1">
-                기술 스택
-              </label>
-
-              <input
-                onChange={onChangeRadio("question")}
-                checked={selectedInputs.questions[0].question === 2}
-                className={styles.radio}
-                name="question"
-                id="2"
-                type="radio"
-                value="career history"
-              />
-              <label className={styles.label} htmlFor="2">
-                경력 사항
-              </label>
-
-              <input
-                onChange={onChangeRadio("question")}
-                checked={selectedInputs.questions[0].question === 3}
-                className={styles.radio}
-                name="question"
-                id="3"
-                type="radio"
-                value="project experience"
-              />
-              <label className={styles.label} htmlFor="3">
-                프로젝트 경험
-              </label>
-            </div>
-            <div className={styles.textareaBox}>
-              <textarea
-                value={selectedInputs.questions[0].questionTextArea}
-                onChange={onChangeText}
-                className={styles.textarea}
-                placeholder="선택한 항목과 관련된 내용을 입력해주세요."
-              />
-            </div>
+            }
           </div>
         </div>
       );
@@ -301,27 +170,71 @@ export default function FormSection({
   }
 }
 
-//  리팩토링 할 때 사용 (컴포넌트 분리 시)
-
-interface RadioInputProps {
-  value: string;
-  name: string;
-  id: string;
-  htmlFor: string;
-  label: string;
+interface SectionFormProps {
+  partSectionNumber: number;
+  selectedInputs: SelectedInputsType;
+  setSelectedInputs: Dispatch<SetStateAction<SelectedInputsType>>;
+  onChangeRadio: ({
+    key,
+    sectionNumber,
+  }: {
+    key: "job" | "career" | "question";
+    sectionNumber?: number;
+  }) => (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-export function RadioInput({
-  htmlFor,
-  id,
-  name,
-  value,
-  label,
-}: RadioInputProps) {
+export function SectionForm({
+  partSectionNumber,
+  selectedInputs,
+  setSelectedInputs,
+  onChangeRadio,
+}: SectionFormProps) {
+  const onChangeText =
+    (partSectionNumber: number) =>
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setSelectedInputs((prev) => {
+        const sectionText = e.target.value;
+        const questionsText = [...prev.questions];
+        questionsText[partSectionNumber].questionTextArea = sectionText;
+
+        return {
+          ...prev,
+          questions: questionsText,
+        };
+      });
+    };
+
   return (
     <>
-      <input name={name} id={id} type="radio" value={value} />
-      <label htmlFor={htmlFor}>{label}</label>
+      <div className={styles.radioInputBox}>
+        {labels.map((question, i) => {
+          return (
+            <RadioInput
+              key={`${question} ${i}`}
+              onChange={onChangeRadio({
+                key: "question",
+                sectionNumber: partSectionNumber,
+              })}
+              checked={
+                selectedInputs.questions[partSectionNumber]?.question === i
+              }
+              name="question"
+              id={i.toString()}
+              value="introduction"
+              label={labels[i]}
+              htmlFor={i.toString()}
+            />
+          );
+        })}
+      </div>
+      <div className={styles.textareaBox}>
+        <textarea
+          value={selectedInputs.questions[partSectionNumber]?.questionTextArea}
+          onChange={onChangeText(partSectionNumber)}
+          className={styles.textarea}
+          placeholder="선택한 항목과 관련된 내용을 입력해주세요."
+        />
+      </div>
     </>
   );
 }

--- a/src/app/resume/components/RadioInput.tsx
+++ b/src/app/resume/components/RadioInput.tsx
@@ -1,0 +1,38 @@
+import styles from "./radioInput.module.css";
+
+interface RadioInputProps {
+  value: string;
+  name: string;
+  id: string;
+  htmlFor: string;
+  label: string;
+  checked: boolean;
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
+}
+
+export function RadioInput({
+  htmlFor,
+  id,
+  name,
+  value,
+  label,
+  checked,
+  onChange,
+}: RadioInputProps) {
+  return (
+    <>
+      <input
+        className={styles.radio}
+        onChange={onChange}
+        checked={checked}
+        name={name}
+        id={id}
+        type="radio"
+        value={value}
+      />
+      <label className={styles.label} htmlFor={htmlFor}>
+        {label}
+      </label>
+    </>
+  );
+}

--- a/src/app/resume/components/formSection.module.css
+++ b/src/app/resume/components/formSection.module.css
@@ -28,52 +28,11 @@
   gap: 15px;
 }
 
-.radio[type="radio"] {
-  display: none;
-}
-
-.radio[type="radio"]:checked + label {
-  background: #5aac8c80;
-  color: #fff;
-}
-
-.label {
-  width: 230px;
-  height: 38px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  color: #fff;
-  background-color: #ffffff20;
-  border: 1px solid #fff;
-  padding: 10px;
-  border-radius: 100px;
-
-  text-align: center;
-
-  cursor: pointer;
-  transition: all 0.3s;
-}
-
-.label:hover {
-  background-color: #ffffff50;
-}
-
 .questionBtns {
   display: flex;
   justify-content: flex-end;
   gap: 10px;
   margin-top: 20px;
-}
-
-.questionBtns input[type="radio"] {
-  display: none;
-}
-
-.questionBtns input[type="radio"]:checked + label {
-  background: #ffffff;
-  color: var(--dark-green);
 }
 
 .questionBtns label {
@@ -91,6 +50,19 @@
   background: #ffffff20;
 
   cursor: pointer;
+}
+
+.questionBtns label:hover {
+  background-color: #ffffff50;
+}
+
+.questionBtns input:checked + label {
+  background-color: #ffffff;
+  color: var(--dark-green);
+}
+
+.questionBtns input[type="radio"] {
+  display: none;
 }
 
 .steps {

--- a/src/app/resume/components/radioInput.module.css
+++ b/src/app/resume/components/radioInput.module.css
@@ -1,0 +1,31 @@
+.radio[type="radio"] {
+  display: none;
+}
+
+.radio[type="radio"]:checked + label {
+  background: #5aac8c80;
+  color: #fff;
+}
+
+.label {
+  width: 230px;
+  height: 38px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  color: #fff;
+  background-color: #ffffff20;
+  border: 1px solid #fff;
+  padding: 10px;
+  border-radius: 100px;
+
+  text-align: center;
+
+  cursor: pointer;
+  transition: all 0.3s;
+}
+
+.label:hover {
+  background-color: #ffffff50;
+}

--- a/src/app/resume/constants/mapping.ts
+++ b/src/app/resume/constants/mapping.ts
@@ -1,0 +1,20 @@
+export const jobsMapping = {
+  0: "Backend Engineer",
+  1: "Frontend Engineer",
+  2: "Fullstack Engineer",
+  3: "Data Engineer",
+};
+
+export const careersMapping = {
+  0: "Newcomer",
+  1: "1~3 years (Junior)",
+  2: "4~7 years (middle)",
+  3: "7 years and up (senior)",
+};
+
+export const questionMapping = {
+  0: "introduction",
+  1: "technology stack",
+  2: "career history",
+  3: "project experience",
+};

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -7,27 +7,11 @@ import customFetch from "@/utils/customFetch";
 import Spinner from "@/components/common/Spinner";
 import { useRouter } from "next/navigation";
 import FormSection from "./components/FormSection";
-
-const jobsMapping = {
-  0: "Backend Engineer",
-  1: "Frontend Engineer",
-  2: "Fullstack Engineer",
-  3: "Data Engineer",
-};
-
-const careersMapping = {
-  0: "Newcomer",
-  1: "1~3 years (Junior)",
-  2: "4~7 years (middle)",
-  3: "7 years and up (senior)",
-};
-
-const questionMapping = {
-  0: "introduction",
-  1: "technology stack",
-  2: "career history",
-  3: "project experience",
-};
+import {
+  careersMapping,
+  jobsMapping,
+  questionMapping,
+} from "./constants/mapping";
 
 const MIN_STEP = 0;
 const MAX_STEP = 2;
@@ -40,6 +24,14 @@ export default function ResumePage() {
     job: 0,
     career: 0,
     questions: [
+      {
+        question: 0,
+        questionTextArea: "",
+      },
+      {
+        question: 0,
+        questionTextArea: "",
+      },
       {
         question: 0,
         questionTextArea: "",
@@ -69,6 +61,13 @@ export default function ResumePage() {
   const onSubmit = async () => {
     const jobIndex = selectedInputs.job as keyof typeof jobsMapping;
     const careerIndex = selectedInputs.career as keyof typeof careersMapping;
+
+    const filteredEmptyQuestions = selectedInputs.questions.filter(
+      (question) => {
+        return !!question.questionTextArea;
+      }
+    );
+
     const categoryIndex = selectedInputs.questions[0]
       .question as keyof typeof questionMapping;
     const body = {
@@ -79,7 +78,9 @@ export default function ResumePage() {
         content: selectedInputs.questions[0].questionTextArea,
       },
     };
-    //  TODO 여러개 항목 요청 시 로직 재 검토 필요
+
+    // TODO 여러개 요청 어떻게 할지 고민해봐야 할듯
+    // 비회원은 강제로 1개만? 회원일 때는..
 
     try {
       setIsLoading(true);
@@ -106,9 +107,9 @@ export default function ResumePage() {
             <Spinner />
           </div>
           <h3>
-            결과를 생성하고 있어요.
+            생성 중입니다. 페이지를 이동하지 마세요.
             <br />
-            잠시만 기다려주세요.
+            현재 beta 버전으로 1번 폼에 작성한 항목에 대해서만 생성됩니다.
           </h3>
         </div>
       )}
@@ -126,7 +127,7 @@ export default function ResumePage() {
 
           <div className={styles.formContainer}>
             <FormSection
-              section={currentStep}
+              step={currentStep}
               selectedInputs={selectedInputs}
               setSelectedInputs={setSelectedInputs}
             />

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -20,14 +20,22 @@ export default function Nav() {
     }
 
     const isTokenExpired = async () => {
-      const res = await fetch("/api/token/exp", {
-        method: "GET",
-        headers: {
-          Authorization: localStorage.getItem("token")!,
-        },
-      });
+      try {
+        const res = await fetch("/api/token/exp", {
+          method: "GET",
+          headers: {
+            Authorization: localStorage.getItem("token")!,
+          },
+        });
 
-      return await res.json();
+        return await res.json();
+      } catch (err) {
+        window.alert("로그인이 만료되었습니다. 재로그인해주세요.");
+        router.push("/login");
+        localStorage.removeItem("token");
+        localStorage.removeItem("refreshToken");
+        logout();
+      }
     };
 
     if (token) {


### PR DESCRIPTION

![Honeycam 2023-10-07 03-51-09](https://github.com/Resumarble/Resumarble-Frontend/assets/48672106/af32d125-f536-4a7d-a108-16953055b474)


## 커밋 사항
- resume 페이지 컴포넌트 분리 및 코드 리팩토링 진행
- 3번째 step 페이지 우측 상단의 숫자 탭에 따른 입력 값 상태 관리 로직 추가

### 기타
- 현재 최대 3개의 항목을 작성은 가능하나, 결과 생성 버튼 클릭 시 맨 첫번째 탭에 작성된 항목만을 결과로 받음. (API 통신 부분은 이전 로직에서 수정하지 않음)
  - 현기준 백엔드 API는 항목 개수만큼 API를 n번 요청하여 응답을 받아야 하는데 이 응답에 대한 모든 내용을 가지고 결과 페이지를 생성하려면 병렬적으로 처리해서 한번에 받아야 함. -> 병렬처리 로직 추가 필요.
  - 비회원과 회원 기능에 차별성을 둬야할지 논의 해보면 좋을 듯 (비회원은 1개만 가능, 회원은 최대 3개까지 작성 가능)