### PR TITLE
[FEAT] mypage 뱃지 컴포넌트, 병렬 처리 추가

### DIFF
--- a/src/app/mypage/mypage.module.css
+++ b/src/app/mypage/mypage.module.css
@@ -1,17 +1,51 @@
 .container {
-  margin-top: 30px;
-  padding: 20px;
-  height: 100vh;
-
-  position: relative;
+  margin-top: 70px;
 }
 
-.container div {
-  overflow: hidden;
-  width: 100%;
+.headerTitle {
+  position: absolute;
+  top: 5px;
+  left: 20px;
+
+  z-index: 10;
+
+  padding-left: 1.2rem;
+  padding-top: 0.3rem;
 }
 
-.container ul {
-  height: 50%;
+.headerTitle::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 8px;
+  width: 4px;
+  height: 55px;
+  background: var(--dark-green);
+}
+
+.headerTitle h5 {
   font-size: 1rem;
+  color: var(--dark-green);
+}
+
+.headerTitle strong {
+  color: var(--dark-green);
+}
+
+.headerTitle p {
+  font-size: 0.88rem;
+  margin-top: -3px;
+  color: var(--dark-green);
+}
+
+.contentsContainer {
+  display: flex;
+  flex-direction: column;
+
+  margin-top: 55px;
+}
+
+.badgeContainer {
+  display: flex;
+  gap: 10px;
 }

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -11,6 +11,7 @@ import useStore from "@/store/zustand/login";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import Button from "@/components/common/Button";
+import Badge from "@/components/common/Badge";
 
 export default function MyPage() {
   const [userId, setUserId] = useState<number>(); // token 복호화 후 id 값 추출
@@ -76,16 +77,23 @@ export default function MyPage() {
 
   return (
     <div className={styles.container}>
-      <Container showTopWhite overflowYScroll>
-        <p>
-          보고 계신 화면은 <strong>개발 진행중</strong>으로 미완성된
-          페이지입니다.
-        </p>
+      <Container
+        showTopWhite
+        overflowYScroll
+        style={{ padding: "10px", overflowY: "scroll", marginTop: "30px" }}
+      >
+        <div className={styles.headerTitle}>
+          <h5>MyPage</h5>
+          <p>
+            <strong>생성한 모든 질문과 답변을 확인하실 수 있어요.</strong>
+          </p>
+          <p>비로그인일 때 생성한 결과는 저장되지 않습니다.</p>
+        </div>
         <br />
         {isLoading || !userId ? (
           <div>데이터를 불러오고 있어요.</div>
         ) : (
-          <div>
+          <div className={styles.contentsContainer}>
             {!predictions.length ? (
               <div>
                 <h2>No data</h2>
@@ -115,14 +123,22 @@ export default function MyPage() {
                   }[];
                 }) => {
                   return (
-                    <div key={`${question_and_answer} ${created_date}`}>
+                    <div
+                      className={styles.content}
+                      key={`${question_and_answer} ${created_date}`}
+                    >
                       {question_and_answer?.map((qna, i) => {
                         return (
                           <ToggleBox
                             key={`${qna} ${i}`}
                             title={qna.question}
                             contents={qna.answer}
-                          ></ToggleBox>
+                          >
+                            <div className={styles.badgeContainer}>
+                              <Badge text={job} />
+                              <Badge text={category} />
+                            </div>
+                          </ToggleBox>
                         );
                       })}
                     </div>

--- a/src/app/result/components/ResultContainer.tsx
+++ b/src/app/result/components/ResultContainer.tsx
@@ -35,24 +35,19 @@ export default function ResultContainer() {
     }
   }, []);
 
-  if (!hasResult) {
-    return (
-      <div className={styles.container}>
-        <div className={styles.box}></div>
-      </div>
-    );
-  }
-
   return (
     <>
-      <Container showTopWhite style={{ padding: "10px", overflowY: "scroll" }}>
-        {!hasResult ? (
-          <>
-            <h3>ERROR!</h3>
-            <h4>올바르지 않은 요청입니다.</h4>
-            <Link href={"/resume"}>다시 작성하기</Link>
-          </>
-        ) : (
+      {!hasResult ? (
+        <div style={{ textAlign: "center" }}>
+          <h3>ERROR!</h3>
+          <h4>올바르지 않은 요청입니다.</h4>
+          <Link href={"/resume"}>다시 작성하기</Link>
+        </div>
+      ) : (
+        <Container
+          showTopWhite
+          style={{ padding: "10px", overflowY: "scroll" }}
+        >
           <>
             <div className={styles.options}>
               <SaveButton txt={resultsForDownload} />
@@ -92,8 +87,8 @@ export default function ResultContainer() {
               </div>
             </div>
           </>
-        )}
-      </Container>
+        </Container>
+      )}
     </>
   );
 }

--- a/src/app/result/components/resultContainer.module.css
+++ b/src/app/result/components/resultContainer.module.css
@@ -66,7 +66,7 @@
 }
 
 .contents {
-  margin-top: 100px;
+  margin-top: 80px;
 }
 
 .content {

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -68,28 +68,35 @@ export default function ResumePage() {
       }
     );
 
-    const categoryIndex = selectedInputs.questions[0]
-      .question as keyof typeof questionMapping;
-    const body = {
-      job: jobsMapping[jobIndex],
-      career: careersMapping[careerIndex],
-      resumeInfo: {
-        category: questionMapping[categoryIndex],
-        content: selectedInputs.questions[0].questionTextArea,
-      },
-    };
-
-    // TODO 여러개 요청 어떻게 할지 고민해봐야 할듯
-    // 비회원은 강제로 1개만? 회원일 때는..
+    if (!filteredEmptyQuestions.length) {
+      return window.alert("내용을 입력해주세요.");
+    }
 
     try {
       setIsLoading(true);
-      const res = await customFetch({
-        url: "/resumes/interview-questions",
-        method: "POST",
-        body,
+      const promises = filteredEmptyQuestions.map(async (_, i) => {
+        const categoryIndex = selectedInputs.questions[i]
+          .question as keyof typeof questionMapping;
+        const body = {
+          job: jobsMapping[jobIndex],
+          career: careersMapping[careerIndex],
+          resumeInfo: {
+            category: questionMapping[categoryIndex],
+            content: selectedInputs.questions[i].questionTextArea,
+          },
+        };
+
+        const res = await customFetch({
+          url: "/resumes/interview-questions",
+          method: "POST",
+          body,
+        });
+
+        return res.data.interviews;
       });
-      localStorage.setItem("result", JSON.stringify(res.data.interviews));
+
+      const results = await Promise.all(promises);
+      localStorage.setItem("result", JSON.stringify(results.flat()));
       route.push("/result");
     } catch (err) {
       console.error(err);
@@ -107,9 +114,9 @@ export default function ResumePage() {
             <Spinner />
           </div>
           <h3>
-            생성 중입니다. 페이지를 이동하지 마세요.
+            생성 중입니다.
             <br />
-            현재 beta 버전으로 1번 폼에 작성한 항목에 대해서만 생성됩니다.
+            페이지를 이동하지 마세요.
           </h3>
         </div>
       )}

--- a/src/components/common/Badge.tsx
+++ b/src/components/common/Badge.tsx
@@ -1,0 +1,14 @@
+import styles from "./badge.module.css";
+
+interface Props {
+  children?: React.ReactNode;
+  text: string;
+}
+
+export default function Badge({ children, text }: Props) {
+  return (
+    <div className={styles.container}>
+      <h5 className={styles.text}>{text}</h5>
+    </div>
+  );
+}

--- a/src/components/common/ToggleBox.tsx
+++ b/src/components/common/ToggleBox.tsx
@@ -27,6 +27,7 @@ export default function ToggleBox({
   return (
     <div className={styles.container}>
       <h2 onClick={handleTitleClick} className={styles.title}>
+        {children}
         {title}
         <i
           className={`${styles.arrow} ${styles[arrowDirection]}`}

--- a/src/components/common/badge.module.css
+++ b/src/components/common/badge.module.css
@@ -1,0 +1,21 @@
+.container {
+  width: fit-content;
+  height: 100%;
+
+  padding: 3px 10px;
+  border-radius: 100px;
+  background-color: #5f946c50;
+  border: 1px solid #ffffff32;
+
+  margin-left: -5px;
+  margin-bottom: 5px;
+}
+
+.text {
+  width: auto;
+  color: #fff;
+  font-weight: 500;
+  font-size: 0.7rem;
+}
+
+/* TODO 뱃지 색상 여러개 */

--- a/src/components/common/toggleBox.module.css
+++ b/src/components/common/toggleBox.module.css
@@ -1,5 +1,5 @@
 .container {
-  margin-bottom: 1rem;
+  margin-bottom: 10px;
   position: relative;
 }
 
@@ -11,6 +11,8 @@
   background-color: #f8f8f850;
   border-radius: 10px;
   border: 1px solid #ffffff50;
+
+  font-weight: 600;
 
   cursor: pointer;
   position: relative;


### PR DESCRIPTION

![Honeycam 2023-10-10 09-43-55](https://github.com/Resumarble/Resumarble-Frontend/assets/48672106/85709280-d929-4fae-a983-9628275b727a)

![Honeycam 2023-10-10 09-44-22](https://github.com/Resumarble/Resumarble-Frontend/assets/48672106/d479f988-69d8-4ca3-a027-41f350c6c2ff)


## 커밋 사항
- 여러 개 폼을 작성할 경우, 병렬 요청 후 완료 시 result 페이지로 라우트
- 생성한 직업, 주제를 확인할 수 있는 뱃지 컴포넌트 추가
- textarea가 빈 값이 아닌 것만 필터링하여 답변 생성

### 기타
- 현재 백엔드 API는 하나의 폼에 대해 1번의 네트워크 요청을 해야 하므로 폼 3개를 모두 작성하여 요청할 경우 최대 3번의 네트워크 요청을 해야 함 -> API 1번 요청 하는 방식으로 변경 예정